### PR TITLE
Update actions

### DIFF
--- a/.github/workflows/docker-publish-dev.yml
+++ b/.github/workflows/docker-publish-dev.yml
@@ -9,10 +9,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Cache Docker layers
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: /tmp/.buildx-cache
           key: ${{ runner.os }}-buildx-${{ github.sha }}
@@ -21,17 +21,17 @@ jobs:
 
       - name: Set up Docker Buildx
         id: buildx
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@v3
 
       - name: Login to Docker Hub
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKER_HUB_USERNAME }}
           password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
 
       - name: Build and push
         id: docker_build
-        uses: docker/build-push-action@v3
+        uses: docker/build-push-action@v6
         with:
           context: ./
           file: ./Dockerfile

--- a/.github/workflows/docker-publish-optional.yml
+++ b/.github/workflows/docker-publish-optional.yml
@@ -9,10 +9,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Cache Docker layers
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: /tmp/.buildx-cache
           key: ${{ runner.os }}-buildx-${{ github.sha }}
@@ -21,17 +21,17 @@ jobs:
 
       - name: Set up Docker Buildx
         id: buildx
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@v3
 
       - name: Login to Docker Hub
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKER_HUB_USERNAME }}
           password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
 
       - name: Build and push
         id: docker_build
-        uses: docker/build-push-action@v3
+        uses: docker/build-push-action@v6
         with:
           context: ./
           file: ./Dockerfile

--- a/.github/workflows/docker-publish-recommended.yml
+++ b/.github/workflows/docker-publish-recommended.yml
@@ -9,10 +9,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Cache Docker layers
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: /tmp/.buildx-cache
           key: ${{ runner.os }}-buildx-${{ github.sha }}
@@ -21,17 +21,17 @@ jobs:
 
       - name: Set up Docker Buildx
         id: buildx
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@v3
 
       - name: Login to Docker Hub
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKER_HUB_USERNAME }}
           password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
 
       - name: Build and push
         id: docker_build
-        uses: docker/build-push-action@v3
+        uses: docker/build-push-action@v6
         with:
           context: ./
           file: ./Dockerfile

--- a/.github/workflows/docker-publish-tag.yml
+++ b/.github/workflows/docker-publish-tag.yml
@@ -10,10 +10,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Cache Docker layers
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: /tmp/.buildx-cache
           key: ${{ runner.os }}-buildx-${{ github.sha }}
@@ -22,21 +22,21 @@ jobs:
 
       - name: Get tag name
         id: get_tag_name
-        run: echo ::set-output name=VERSION::${GITHUB_REF/refs\/tags\//}
+        run: echo "VERSION=${GITHUB_REF/refs\/tags\//}" >> $GITHUB_OUTPUT
 
       - name: Set up Docker Buildx
         id: buildx
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@v3
 
       - name: Login to Docker Hub
-        uses: docker/login-action@v2
+        uses: docker/login-action@v3
         with:
           username: ${{ secrets.DOCKER_HUB_USERNAME }}
           password: ${{ secrets.DOCKER_HUB_ACCESS_TOKEN }}
 
       - name: Build and push
         id: docker_build
-        uses: docker/build-push-action@v3
+        uses: docker/build-push-action@v6
         with:
           context: ./
           file: ./Dockerfile

--- a/.github/workflows/new-fxserver-version-released.yml
+++ b/.github/workflows/new-fxserver-version-released.yml
@@ -26,11 +26,11 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event.inputs.latest && github.event.inputs.latest_url
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
           ssh-key: "${{ secrets.COMMIT_KEY }}"
-      - uses: mukunku/tag-exists-action@v1.2.0
+      - uses: mukunku/tag-exists-action@v1.6.0
         id: checkTag
         with:
           tag: ${{ github.event.inputs.latest }}
@@ -59,7 +59,7 @@ jobs:
     if: github.event.inputs.recommended && always()
     needs: ["new-tag"]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           ref: "${{ github.event.inputs.recommended }}"
           ssh-key: "${{ secrets.COMMIT_KEY }}"
@@ -71,7 +71,7 @@ jobs:
       - name: Push new release branch
         run: git push --set-upstream origin ${{ github.event.inputs.recommended }}_to_recommended
 #      - name: Switch to recommended
-#        uses: actions/checkout@v3
+#        uses: actions/checkout@v4
 #        with:
 #          ref: "recommended"
 #      - name: Create PR
@@ -90,7 +90,7 @@ jobs:
     if: github.event.inputs.optional && always()
     needs: ["new-tag", "new-recommended"]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           ref: "${{ github.event.inputs.optional }}"
           ssh-key: "${{ secrets.COMMIT_KEY }}"
@@ -102,7 +102,7 @@ jobs:
       - name: Push new release branch
         run: git push --set-upstream origin ${{ github.event.inputs.optional }}_to_optional
 #      - name: Switch to optional
-#        uses: actions/checkout@v3
+#        uses: actions/checkout@v4
 #        with:
 #          ref: "optional"
 #      - name: Create PR


### PR DESCRIPTION
to fix deprecation warnings. see

- https://github.blog/changelog/2024-03-07-github-actions-all-actions-will-run-on-node20-instead-of-node16-by-default/
- https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

no breaking changes as far as i could tell.

see 

- new-fxserver-version-released https://github.com/madmini/fxserver/actions/runs/9810004644
- docker-publish-tag https://github.com/madmini/fxserver/actions/runs/9810088735
- https://hub.docker.com/r/dermini/fxserver/tags